### PR TITLE
adding mozlenium test checks and shared secrets

### DIFF
--- a/k8s/releases/mozalert/mozlenium-shared-secrets.yaml
+++ b/k8s/releases/mozalert/mozlenium-shared-secrets.yaml
@@ -1,0 +1,13 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: mozlenium-shared-secrets
+  namespace: mozalert-prod
+spec:
+  backendType: gcpSecretsManager
+  projectId: mozilla-it-service-engineering
+  data:
+    - key: itse-apps-prod-2-mozlenium-shared
+      version: latest
+      name: SSO_LDAP_PASSWORD
+      property: SSO_LDAP_PASSWORD

--- a/k8s/releases/mozalert/mozlenium-wiki-secrets.yaml
+++ b/k8s/releases/mozalert/mozlenium-wiki-secrets.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: mozlenium-wiki-secrets
+  namespace: mozalert-prod
+spec:
+  backendType: gcpSecretsManager
+  projectId: mozilla-it-service-engineering
+  data:
+    - key: itse-apps-prod-2-mozlenium-shared
+      version: latest
+      name: WIKI_USER
+      property: WIKI_USER
+    - key: itse-apps-prod-2-mozlenium-shared
+      version: latest
+      name: WIKI_PASSWORD
+      property: WIKI_PASSWORD

--- a/k8s/workloads/checks/itse/check-test-login.yaml
+++ b/k8s/workloads/checks/itse/check-test-login.yaml
@@ -1,0 +1,72 @@
+---
+# define intervals and escalations
+# in your Check resource
+apiVersion: "crd.k8s.afrank.local/v1"
+kind: Check
+metadata:
+  name: check-test-login-chrome
+  namespace: mozalert-prod
+  labels:
+    team: itse
+    type: mozlenium
+spec:
+  check_interval: 3m
+  retry_interval: 1m
+  notification_interval: 15m
+  max_attempts: 50
+  escalations:
+  - type: slack
+    env_args:
+      webhook_url: "SLACK_DEFAULT_WEBHOOK_URL"
+      channel: "SLACK_DEFAULT_CHANNEL"
+  image: afrank/mozlenium
+  args: [ "chrome" ]
+  check_cm: check-test-login-cm
+
+---
+# define intervals and escalations
+# in your Check resource
+apiVersion: "crd.k8s.afrank.local/v1"
+kind: Check
+metadata:
+  name: check-test-login-nightly
+  namespace: mozalert-prod
+  labels:
+    team: itse
+    type: mozlenium
+spec:
+  check_interval: 3m
+  retry_interval: 1m
+  notification_interval: 15m
+  max_attempts: 50
+  escalations:
+  - type: slack
+    env_args:
+      webhook_url: "SLACK_DEFAULT_WEBHOOK_URL"
+      channel: "SLACK_DEFAULT_CHANNEL"
+  image: afrank/mozlenium
+  args: [ "firefox" ]
+  check_cm: check-test-login-cm
+
+---
+# here is the check itself, stored in a configmap
+# this block was generated with 
+# k create configmap check-test-1-cm --from-file=./demo-check.js
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: check-test-login-cm
+  namespace: mozalert-prod
+data:
+  demo-check.js: |+
+    //demo check
+
+    var assert = require('assert');
+    var url = 'https://duckduckgo.com'
+
+    console.log("starting check");
+
+    $browser.get(url).then(function(){
+        assert.ok($browser.waitForAndFindElement($driver.By.id("content_homepage"), 30000), "Doesn't seem like things are working properly");
+        console.log("well that went great");
+    })

--- a/k8s/workloads/checks/itse/check-test-ping.yaml
+++ b/k8s/workloads/checks/itse/check-test-ping.yaml
@@ -1,0 +1,23 @@
+---
+# define intervals and escalations
+# in your Check resource
+apiVersion: "crd.k8s.afrank.local/v1"
+kind: Check
+metadata:
+  name: check-test-ping
+  namespace: mozalert-prod
+  labels:
+    team: itse
+    type: pinger
+spec:
+  check_interval: 3m
+  retry_interval: 1m
+  notification_interval: 15m
+  max_attempts: 50
+  image: afrank/pinger
+  check_url: https://www.mozilla.org
+  escalations:
+  - type: slack
+    env_args:
+      webhook_url: "SLACK_DEFAULT_WEBHOOK_URL"
+      channel: "SLACK_DEFAULT_CHANNEL"


### PR DESCRIPTION
Adding some test checks to prod-2 along with the shared secrets to run the rest of the checks. 

Here's a description of how I deployed the secrets into secret manager for the external secrets defined here: https://gist.github.com/mozafrank/583c074978b5285d1d80466b408d2813