### PR TITLE
Disable check-sumo-tp-ping during maintenance

### DIFF
--- a/k8s/workloads/checks/itse/check-sumo-tp-ping.yaml
+++ b/k8s/workloads/checks/itse/check-sumo-tp-ping.yaml
@@ -17,8 +17,3 @@ spec:
   max_attempts: 3
   image: afrank/pinger
   check_url: https://prod-tp.sumo.mozit.cloud/
-  escalations:
-  - type: slack
-    env_args:
-      webhook_url: "SLACK_DEFAULT_WEBHOOK_URL"
-      channel: "SLACK_DEFAULT_CHANNEL"


### PR DESCRIPTION
I'll verify why this fails when traffic goes to frankfurt