### PR TITLE
disabling notifications on check-observatory-frontend-ping

### DIFF
--- a/k8s/workloads/checks/eis/check-observatory-frontend-ping.yaml
+++ b/k8s/workloads/checks/eis/check-observatory-frontend-ping.yaml
@@ -16,8 +16,3 @@ spec:
   max_attempts: 3
   image: afrank/pinger
   check_url: https://sshscan.rubidus.com/
-  escalations:
-  - type: slack
-    env_args:
-      webhook_url: "SLACK_DEFAULT_WEBHOOK_URL"
-      channel: "SLACK_DEFAULT_CHANNEL"


### PR DESCRIPTION
the ssl cert failed on the domain being checked here, but we don't own the cert or the domain, so disabling the alert.